### PR TITLE
Fix alert-dismissible .close

### DIFF
--- a/css/bootstrap-ie8.css
+++ b/css/bootstrap-ie8.css
@@ -29,7 +29,7 @@ h6,.h6{font-size:16px}
 
 .alert{margin-bottom:16px;padding:12px}
 .alert-dismissible{padding-right:40px}
-.alert-dismissible .close{top:-2px;right:-20px}
+.alert-dismissible .close{top:-2px}
 .blockquote{padding:8px 16px;margin-bottom:16px;font-size:20px}
 .blockquote-footer:before{content: "\2014 \00A0";}
 

--- a/test.htm
+++ b/test.htm
@@ -1818,12 +1818,16 @@
     </footer>
   </div>
   <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.6/umd/popper.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
 
   <!--[if IE]>
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-	<script>$('input, textarea').placeholder();</script>
+	<script>
+    $(function() {
+    $('input, textarea').placeholder();
+    };
+  </script>
 		<![endif]-->
 </body>
 


### PR DESCRIPTION
Fix alert-dismissible .close popping out of the box.
Minor test page update to update popper JS and change placeholder polyfill