### PR TITLE
SVG images with .img-fluid are disproportionately sized on IE9

### DIFF
--- a/css/bootstrap-ie9.css
+++ b/css/bootstrap-ie9.css
@@ -86,6 +86,9 @@ aside,
   background-image: none;
   padding-right: .75rem;
 }
+.img-fluid[src$=".svg"] {
+  width: 100%;
+}
 .table-responsive {
   min-height: 0%;
 } /* see https://github.com/twbs/bootstrap/issues/14837 */


### PR DESCRIPTION
/* REF: https://github.com/twbs/bootstrap/issues/23476 */
  .img-fluid[src$=".svg"] {
    width: 100% \9;
  }
